### PR TITLE
Update deprecated (and removed) register_format call

### DIFF
--- a/descale.py
+++ b/descale.py
@@ -35,7 +35,7 @@ def Descale(src, width, height, kernel=None, custom_kernel=None, taps=None, b=No
         return rgb.resize.Point(format=src_f.id)
 
     y = to_grays(src).descale.Descale(width, height, kernel, custom_kernel, taps, b, c)
-    y_f = core.register_format(GRAY, src_st, src_bits, 0, 0)
+    y_f = core.query_video_format(GRAY, src_st, src_bits, 0, 0)
     y = y.resize.Point(format=y_f.id)
 
     if src_cf == GRAY or gray:
@@ -44,7 +44,7 @@ def Descale(src, width, height, kernel=None, custom_kernel=None, taps=None, b=No
     if not yuv444 and ((width % 2 and src_sw) or (height % 2 and src_sh)):
         raise ValueError('Descale: The output dimension and the subsampling are incompatible.')
 
-    uv_f = core.register_format(src_cf, src_st, src_bits, 0 if yuv444 else src_sw, 0 if yuv444 else src_sh)
+    uv_f = core.query_video_format(src_cf, src_st, src_bits, 0 if yuv444 else src_sw, 0 if yuv444 else src_sh)
     uv = src.resize.Spline36(width, height, format=uv_f.id, chromaloc_s=chromaloc)
 
     return core.std.ShufflePlanes([y,uv], [0,1,2], YUV)


### PR DESCRIPTION
VapourSynth removed a bunch of previously deprecated functions including register_format, this just updates that to the replacement.