### PR TITLE
Add "mirror" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ The VapourSynth plugin itself supports every constant input format. If the forma
 The included python wrapper, contrary to using the plugin directly, doesn't descale the chroma planes but scales them normally with `Spline36`.
 
 ```
-descale.Debilinear(clip src, int width, int height, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, int opt=0)
+descale.Debilinear(clip src, int width, int height, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, bool mirror=True, int opt=0)
 
-descale.Debicubic(clip src, int width, int height, float b=0.0, float c=0.5, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, int opt=0)
+descale.Debicubic(clip src, int width, int height, float b=0.0, float c=0.5, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, bool mirror=True, int opt=0)
 
-descale.Delanczos(clip src, int width, int height, int taps=3, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, int opt=0)
+descale.Delanczos(clip src, int width, int height, int taps=3, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, bool mirror=True, int opt=0)
 
-descale.Despline16(clip src, int width, int height, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, int opt=0)
+descale.Despline16(clip src, int width, int height, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, bool mirror=True, int opt=0)
 
-descale.Despline36(clip src, int width, int height, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, int opt=0)
+descale.Despline36(clip src, int width, int height, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, bool mirror=True, int opt=0)
 
-descale.Despline64(clip src, int width, int height, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, int opt=0)
+descale.Despline64(clip src, int width, int height, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, bool mirror=True, int opt=0)
 
-descale.Descale(clip src, int width, int height, str kernel, func custom_kernel, int taps=3, float b=0.0, float c=0.0, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, int opt=0)
+descale.Descale(clip src, int width, int height, str kernel, func custom_kernel, int taps=3, float b=0.0, float c=0.0, float src_left=0.0, float src_top=0.0, float src_width=width, float src_height=height, bool force, bool force_h, bool force_v, bool mirror=True, int opt=0)
 ```
 
 The AviSynth+ plugin is used similarly, but without the `descale` namespace.

--- a/include/descale.h
+++ b/include/descale.h
@@ -24,6 +24,7 @@
 #ifndef DESCALE_H
 #define DESCALE_H
 
+#include <stdbool.h>
 
 typedef enum DescaleMode
 {
@@ -68,6 +69,7 @@ typedef struct DescaleParams
     double param2;      // required if mode is BICUBIC
     double shift;       // optional
     double active_dim;  // always required; usually equal to dst_dim
+    bool no_mirror;     // optional
     DescaleCustomKernel custom_kernel;  // required if mode is CUSTOM
 } DescaleParams;
 

--- a/src/avsplugin.c
+++ b/src/avsplugin.c
@@ -268,6 +268,9 @@ static AVS_Value AVSC_CC avs_descale_create(AVS_ScriptEnvironment *env, AVS_Valu
     }
 
     v = avs_array_elt(args, idx++);
+    bool mirror = avs_as_bool(v);
+
+    v = avs_array_elt(args, idx++);
     int opt = avs_defined(v) ? avs_as_int(v) : 0;
     enum DescaleOpt opt_enum;
     if (opt == 1)
@@ -279,7 +282,7 @@ static AVS_Value AVSC_CC avs_descale_create(AVS_ScriptEnvironment *env, AVS_Valu
 
     int bits_per_pixel = avs_bits_per_component(vi);
     if (bits_per_pixel != 32) {
-        AVS_Value c2, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11;
+        AVS_Value c2, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12;
         c1 = avs_new_value_clip(clip);
         avs_release_clip(clip);
         a1 = avs_new_value_int(32);
@@ -296,9 +299,10 @@ static AVS_Value AVSC_CC avs_descale_create(AVS_ScriptEnvironment *env, AVS_Valu
         a8 = avs_new_value_float(shift_v);
         a9 = avs_new_value_float(active_width);
         a10 = avs_new_value_float(active_height);
-        a11 = avs_new_value_int(opt);
-        AVS_Value descale_args[] = {c2, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11};
-        c1 = avs_invoke(env, "Descale", avs_new_value_array(descale_args, 12), NULL);
+        a11 = avs_new_value_bool(mirror);
+        a12 = avs_new_value_int(opt);
+        AVS_Value descale_args[] = {c2, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12};
+        c1 = avs_invoke(env, "Descale", avs_new_value_array(descale_args, 13), NULL);
         avs_release_value(c2);
         a1 = avs_new_value_int(bits_per_pixel);
         AVS_Value convert_args2[] = {c1, a1};
@@ -307,7 +311,7 @@ static AVS_Value AVSC_CC avs_descale_create(AVS_ScriptEnvironment *env, AVS_Valu
         return c2;
     }
 
-    struct DescaleParams params = {mode, taps, b, c, 0, 0};
+    struct DescaleParams params = {mode, taps, b, c, 0, 0, !mirror};
     struct DescaleData dd = {
         src_width, src_height,
         dst_width, dst_height,
@@ -359,6 +363,7 @@ const char * AVSC_CC avisynth_c_plugin_init(AVS_ScriptEnvironment *env)
         "[src_top]f"
         "[src_width]f"
         "[src_height]f"
+        "[mirror]b"
         "[opt]i",
         avs_descale_create,
         (void *)(DESCALE_MODE_BILINEAR)
@@ -376,6 +381,7 @@ const char * AVSC_CC avisynth_c_plugin_init(AVS_ScriptEnvironment *env)
         "[src_top]f"
         "[src_width]f"
         "[src_height]f"
+        "[mirror]b"
         "[opt]i",
         avs_descale_create,
         (void *)(DESCALE_MODE_BICUBIC)
@@ -392,6 +398,7 @@ const char * AVSC_CC avisynth_c_plugin_init(AVS_ScriptEnvironment *env)
         "[src_top]f"
         "[src_width]f"
         "[src_height]f"
+        "[mirror]b"
         "[opt]i",
         avs_descale_create,
         (void *)(DESCALE_MODE_LANCZOS)
@@ -407,6 +414,7 @@ const char * AVSC_CC avisynth_c_plugin_init(AVS_ScriptEnvironment *env)
         "[src_top]f"
         "[src_width]f"
         "[src_height]f"
+        "[mirror]b"
         "[opt]i",
         avs_descale_create,
         (void *)(DESCALE_MODE_SPLINE16)
@@ -422,6 +430,7 @@ const char * AVSC_CC avisynth_c_plugin_init(AVS_ScriptEnvironment *env)
         "[src_top]f"
         "[src_width]f"
         "[src_height]f"
+        "[mirror]b"
         "[opt]i",
         avs_descale_create,
         (void *)(DESCALE_MODE_SPLINE36)
@@ -437,6 +446,7 @@ const char * AVSC_CC avisynth_c_plugin_init(AVS_ScriptEnvironment *env)
         "[src_top]f"
         "[src_width]f"
         "[src_height]f"
+        "[mirror]b"
         "[opt]i",
         avs_descale_create,
         (void *)(DESCALE_MODE_SPLINE64)
@@ -456,6 +466,7 @@ const char * AVSC_CC avisynth_c_plugin_init(AVS_ScriptEnvironment *env)
         "[src_top]f"
         "[src_width]f"
         "[src_height]f"
+        "[mirror]b"
         "[opt]i",
         avs_descale_create,
         NULL

--- a/src/descale.c
+++ b/src/descale.c
@@ -23,7 +23,6 @@
 
 #include <float.h>
 #include <math.h>
-#include <stdbool.h>
 #include <stdlib.h>
 #include "common.h"
 #include "descale.h"
@@ -244,7 +243,7 @@ static double round_halfup(double x)
 
 // Most of this is taken from zimg 
 // https://github.com/sekrit-twc/zimg/blob/ce27c27f2147fbb28e417fbf19a95d3cf5d68f4f/src/zimg/resize/filter.cpp#L227
-static void scaling_weights(enum DescaleMode mode, int support, int src_dim, int dst_dim, double param1, double param2, double shift, double active_dim, struct DescaleCustomKernel *ck, double **weights)
+static void scaling_weights(enum DescaleMode mode, int support, int src_dim, int dst_dim, double param1, double param2, double shift, double active_dim, bool mirror, struct DescaleCustomKernel *ck, double **weights)
 {
     *weights = calloc(src_dim * dst_dim, sizeof (double));
     double ratio = (double)dst_dim / active_dim;
@@ -260,18 +259,24 @@ static void scaling_weights(enum DescaleMode mode, int support, int src_dim, int
         }
         for (int j = 0; j < 2 * support; j++) {
             double xpos = begin_pos + j;
-            double real_pos;
+            if (mirror) {
+                double real_pos;
 
-            // Mirror the position if it goes beyond image bounds.
-            if (xpos < 0.0)
-                real_pos = -xpos;
-            else if (xpos >= src_dim)
-                real_pos = DSMIN(2.0 * src_dim - xpos, src_dim - 0.5);
-            else
-                real_pos = xpos;
+                // Mirror the position if it goes beyond image bounds.
+                if (xpos < 0.0)
+                    real_pos = -xpos;
+                else if (xpos >= src_dim)
+                    real_pos = DSMIN(2.0 * src_dim - xpos, src_dim - 0.5);
+                else
+                    real_pos = xpos;
 
-            int idx = (int)floor(real_pos);
-            (*weights)[i * src_dim + idx] += calculate_weight(mode, support, xpos - pos, param1, param2, ck) / total;
+                int idx = (int)floor(real_pos);
+                (*weights)[i * src_dim + idx] += calculate_weight(mode, support, xpos - pos, param1, param2, ck) / total;
+            }
+            else if (xpos >= 0.0 && xpos < src_dim) {
+                int idx = (int)floor(xpos);
+                (*weights)[i * src_dim + idx] += calculate_weight(mode, support, xpos - pos, param1, param2, ck) / total;
+            }
         }
     }
 }
@@ -587,7 +592,7 @@ static struct DescaleCore *create_core(int src_dim, int dst_dim, struct DescaleP
     double *multiplied_weights;
     double *lower;
 
-    scaling_weights(params->mode, support, dst_dim, src_dim, params->param1, params->param2, params->shift, params->active_dim, &params->custom_kernel, &weights);
+    scaling_weights(params->mode, support, dst_dim, src_dim, params->param1, params->param2, params->shift, params->active_dim, !params->no_mirror, &params->custom_kernel, &weights);
     transpose_matrix(src_dim, dst_dim, weights, &transposed_weights);
 
     core.weights_left_idx = calloc(ceil_n(dst_dim, 8), sizeof (int));

--- a/src/vsplugin.c
+++ b/src/vsplugin.c
@@ -353,6 +353,10 @@ static void VS_CC descale_create(const VSMap *in, VSMap *out, void *user_data, V
         funcname = "none";
     }
 
+    params.no_mirror = !!vsapi->mapGetInt(in, "mirror", 0, &err);
+    if (err)
+        params.no_mirror = false;
+
     int force = vsapi->mapGetIntSaturated(in, "force", 0, &err);
     int force_h = vsapi->mapGetIntSaturated(in, "force_h", 0, &err);
     if (err)
@@ -422,6 +426,7 @@ static void VS_CC descale_create(const VSMap *in, VSMap *out, void *user_data, V
         vsapi->mapSetInt(map1, "force", force, maReplace);
         vsapi->mapSetInt(map1, "force_h", force_h, maReplace);
         vsapi->mapSetInt(map1, "force_v", force_v, maReplace);
+        vsapi->mapSetInt(map1, "mirror", !params.no_mirror, maReplace);
         vsapi->mapSetInt(map1, "opt", (int)opt_enum, maReplace);
         map2 = vsapi->invoke(descale_plugin, "Descale", map1);
         vsapi->freeNode(tmp_node);
@@ -482,6 +487,7 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit2(VSPlugin *plugin, const VSPLUGINAPI
             "src_top:float:opt;"
             "src_width:float:opt;"
             "src_height:float:opt;"
+            "mirror:int:opt;"
             "opt:int:opt;",
             "clip:vnode;",
             descale_create, (void *)(DESCALE_MODE_BILINEAR), plugin);
@@ -499,6 +505,7 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit2(VSPlugin *plugin, const VSPLUGINAPI
             "force:int:opt;"
             "force_h:int:opt;"
             "force_v:int:opt;"
+            "mirror:int:opt;"
             "opt:int:opt;",
             "clip:vnode;",
             descale_create, (void *)(DESCALE_MODE_BICUBIC), plugin);
@@ -515,6 +522,7 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit2(VSPlugin *plugin, const VSPLUGINAPI
             "force:int:opt;"
             "force_h:int:opt;"
             "force_v:int:opt;"
+            "mirror:int:opt;"
             "opt:int:opt;",
             "clip:vnode;",
             descale_create, (void *)(DESCALE_MODE_LANCZOS), plugin);
@@ -530,6 +538,7 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit2(VSPlugin *plugin, const VSPLUGINAPI
             "force:int:opt;"
             "force_h:int:opt;"
             "force_v:int:opt;"
+            "mirror:int:opt;"
             "opt:int:opt;",
             "clip:vnode;",
             descale_create, (void *)(DESCALE_MODE_SPLINE16), plugin);
@@ -545,6 +554,7 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit2(VSPlugin *plugin, const VSPLUGINAPI
             "force:int:opt;"
             "force_h:int:opt;"
             "force_v:int:opt;"
+            "mirror:int:opt;"
             "opt:int:opt;",
             "clip:vnode;",
             descale_create, (void *)(DESCALE_MODE_SPLINE36), plugin);
@@ -560,6 +570,7 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit2(VSPlugin *plugin, const VSPLUGINAPI
             "force:int:opt;"
             "force_h:int:opt;"
             "force_v:int:opt;"
+            "mirror:int:opt;"
             "opt:int:opt;",
             "clip:vnode;",
             descale_create, (void *)(DESCALE_MODE_SPLINE64), plugin);
@@ -580,6 +591,7 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit2(VSPlugin *plugin, const VSPLUGINAPI
             "force:int:opt;"
             "force_h:int:opt;"
             "force_v:int:opt;"
+            "mirror:int:opt;"
             "opt:int:opt;",
             "clip:vnode;",
             descale_create, NULL, plugin);

--- a/src/vsplugin.c
+++ b/src/vsplugin.c
@@ -353,7 +353,7 @@ static void VS_CC descale_create(const VSMap *in, VSMap *out, void *user_data, V
         funcname = "none";
     }
 
-    params.no_mirror = !!vsapi->mapGetInt(in, "mirror", 0, &err);
+    params.no_mirror = !vsapi->mapGetInt(in, "mirror", 0, &err);
     if (err)
         params.no_mirror = false;
 


### PR DESCRIPTION
This is corresponding to part 2 of #8 with a satisfactory result on the test image.

The default value of the parameter is True. When it's set to False, reflection on the boundaries are ignored in the weight matrix calculation, which matches the behavior of certain old applications.