### PR TITLE
Add "Repeat" mode for border handling

### DIFF
--- a/descale.py
+++ b/descale.py
@@ -5,6 +5,7 @@ from vapoursynth import core, GRAYS, RGBS, GRAY, YUV, RGB
 class BorderHandling(IntEnum):
     MIRROR = 0
     ZERO = 1
+    REPEAT = 2
 
 class Opt(IntEnum):
     AUTO = 0

--- a/include/descale.h
+++ b/include/descale.h
@@ -47,7 +47,8 @@ typedef enum DescaleDir
 typedef enum DescaleBorder
 {
     DESCALE_BORDER_MIRROR = 0,
-    DESCALE_BORDER_ZERO   = 1
+    DESCALE_BORDER_ZERO   = 1,
+    DESCALE_BORDER_REPEAT = 2
 } DescaleBorder;
 
 

--- a/src/avsplugin.c
+++ b/src/avsplugin.c
@@ -272,6 +272,8 @@ static AVS_Value AVSC_CC avs_descale_create(AVS_ScriptEnvironment *env, AVS_Valu
     enum DescaleBorder border_handling_enum;
     if (border_handling == 1)
         border_handling_enum = DESCALE_BORDER_ZERO;
+    if (border_handling == 2)
+        border_handling_enum = DESCALE_BORDER_REPEAT;
     else
         border_handling_enum = DESCALE_BORDER_MIRROR;
 

--- a/src/descale.c
+++ b/src/descale.c
@@ -265,6 +265,11 @@ static void scaling_weights(enum DescaleMode mode, int support, int src_dim, int
             if (xpos < 0.0 || xpos > src_dim) {
                 if (border_handling == DESCALE_BORDER_ZERO) {
                     continue;
+                } else if (border_handling == DESCALE_BORDER_REPEAT) {
+                    if (xpos < 0.0)
+                        real_pos = 0.0;
+                    else if (xpos >= src_dim)
+                        real_pos = src_dim - 0.5;
                 } else {    // Mirror
                     if (xpos < 0.0)
                         real_pos = -xpos;

--- a/src/descale.c
+++ b/src/descale.c
@@ -258,30 +258,23 @@ static void scaling_weights(enum DescaleMode mode, int support, int src_dim, int
             double xpos = begin_pos + j;
             total += calculate_weight(mode, support, xpos - pos, param1, param2, ck);
         }
-        if (border_handling == DESCALE_BORDER_ZERO) {
-            for (int j = 0; j < 2 * support; j++) {
-                double xpos = begin_pos + j;
-                if (xpos >= 0.0 && xpos < src_dim) {
-                    int idx = (int)floor(xpos);
-                    (*weights)[i * src_dim + idx] += calculate_weight(mode, support, xpos - pos, param1, param2, ck) / total;
+        for (int j = 0; j < 2 * support; j++) {
+            double xpos = begin_pos + j;
+            double real_pos = xpos;
+
+            if (xpos < 0.0 || xpos > src_dim) {
+                if (border_handling == DESCALE_BORDER_ZERO) {
+                    continue;
+                } else {    // Mirror
+                    if (xpos < 0.0)
+                        real_pos = -xpos;
+                    else if (xpos >= src_dim)
+                        real_pos = DSMIN(2.0 * src_dim - xpos, src_dim - 0.5);
                 }
             }
-        } else {
-            for (int j = 0; j < 2 * support; j++) {
-                double xpos = begin_pos + j;
-                double real_pos;
 
-                // Mirror the position if it goes beyond image bounds.
-                if (xpos < 0.0)
-                    real_pos = -xpos;
-                else if (xpos >= src_dim)
-                    real_pos = DSMIN(2.0 * src_dim - xpos, src_dim - 0.5);
-                else
-                    real_pos = xpos;
-
-                int idx = (int)floor(real_pos);
-                (*weights)[i * src_dim + idx] += calculate_weight(mode, support, xpos - pos, param1, param2, ck) / total;
-            }
+            int idx = (int)floor(real_pos);
+            (*weights)[i * src_dim + idx] += calculate_weight(mode, support, xpos - pos, param1, param2, ck) / total;
         }
     }
 }

--- a/src/vsplugin.c
+++ b/src/vsplugin.c
@@ -268,6 +268,8 @@ static void VS_CC descale_create(const VSMap *in, VSMap *out, void *user_data, V
         border_handling = 0;
     if (border_handling == 1)
         params.border_handling = DESCALE_BORDER_ZERO;
+    else if (border_handling == 2)
+        params.border_handling = DESCALE_BORDER_REPEAT;
     else
         params.border_handling = DESCALE_BORDER_MIRROR;
 


### PR DESCRIPTION
Since a few people asked for this, this PR adds another border handling mode that simply extends the last row of pixels in each direction instead of mirroring.